### PR TITLE
Remove empty catch statements

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -1068,7 +1068,6 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
                     inetAddresses = getAddressesFromNameService(host);
                     // don't update the "expirySet", will do that later
                     staleTime = refreshTime + InetAddressCachePolicy.getStale() * 1000_000_000L;
-                } catch (UnknownHostException ignore) {
                 } finally {
                     lookupLock.unlock();
                 }

--- a/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java
@@ -805,7 +805,6 @@ public class ThreadPoolExecutor extends AbstractExecutorService {
                 if (!t.isInterrupted() && w.tryLock()) {
                     try {
                         t.interrupt();
-                    } catch (SecurityException ignore) {
                     } finally {
                         w.unlock();
                     }

--- a/src/java.base/share/classes/sun/net/www/http/HttpCapture.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpCapture.java
@@ -97,8 +97,6 @@ public class HttpCapture {
                     }
                     line = in.readLine();
                 }
-            } catch (IOException ioe) {
-
             } finally {
                 try {
                     in.close();

--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/jpeg/JPEGImageReader.java
@@ -415,7 +415,6 @@ public class JPEGImageReader extends ImageReader {
         try {
             gotoImage(imageIndex);
             skipImage();
-        } catch (IOException | IndexOutOfBoundsException e) {
         } finally {
             cbLock.unlock();
         }

--- a/src/java.desktop/share/classes/com/sun/imageio/stream/CloseableDisposerRecord.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/stream/CloseableDisposerRecord.java
@@ -45,7 +45,6 @@ public class CloseableDisposerRecord implements DisposerRecord {
         if (closeable != null) {
             try {
                 closeable.close();
-            } catch (IOException e) {
             } finally {
                 closeable = null;
             }

--- a/src/java.desktop/share/classes/com/sun/imageio/stream/StreamFinalizer.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/stream/StreamFinalizer.java
@@ -64,7 +64,6 @@ public class StreamFinalizer {
     protected void finalize() throws Throwable {
         try {
             stream.close();
-        } catch (IOException e) {
         } finally {
             stream = null;
             super.finalize();

--- a/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
+++ b/src/java.desktop/share/classes/javax/imageio/stream/FileCacheImageInputStream.java
@@ -286,7 +286,6 @@ public class FileCacheImageInputStream extends ImageInputStreamImpl {
             if (cache != null) {
                 try {
                     cache.close();
-                } catch (IOException e) {
                 } finally {
                     cache = null;
                 }

--- a/src/java.desktop/share/classes/javax/swing/TimerQueue.java
+++ b/src/java.desktop/share/classes/javax/swing/TimerQueue.java
@@ -186,7 +186,6 @@ class TimerQueue implements Runnable
 
                         // Allow run other threads on systems without kernel threads
                         timer.getLock().newCondition().awaitNanos(1);
-                    } catch (SecurityException ignore) {
                     } finally {
                         timer.getLock().unlock();
                     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1256,7 +1256,6 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
                     Rectangle rect = (toDamage instanceof Rectangle) ?
                             (Rectangle)toDamage : toDamage.getBounds();
                     editor.repaint(rect.x, rect.y, rect.width, rect.height);
-                } catch (BadLocationException e) {
                 } finally {
                     if (doc instanceof AbstractDocument) {
                         ((AbstractDocument)doc).readUnlock();

--- a/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
+++ b/src/java.desktop/share/classes/javax/swing/text/JTextComponent.java
@@ -2844,7 +2844,6 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
                      (Rectangle)bounds : bounds.getBounds();
 
                 }
-            } catch (BadLocationException e) {
             } finally {
                 if (model instanceof AbstractDocument) {
                     ((AbstractDocument)model).readUnlock();
@@ -3042,7 +3041,6 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
                 default:
                     break;
                 }
-            } catch (BadLocationException e) {
             } finally {
                 if (model instanceof AbstractDocument) {
                     ((AbstractDocument)model).readUnlock();
@@ -3365,9 +3363,6 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
                             model.getText(index + direction, 1));
                     }
 
-                } catch (BadLocationException e) {
-                    // we are intentionally silent; our contract says we return
-                    // null if there is any failure in this method
                 } finally {
                     if (model instanceof AbstractDocument) {
                         ((AbstractDocument)model).readUnlock();
@@ -3725,7 +3720,6 @@ public abstract class JTextComponent extends JComponent implements Scrollable, A
                      (Rectangle)bounds : bounds.getBounds();
 
                 }
-            } catch (BadLocationException e) {
             } finally {
                 if (model instanceof AbstractDocument) {
                     ((AbstractDocument)model).readUnlock();

--- a/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
@@ -1061,7 +1061,6 @@ class AccessibleHTML implements Accessible {
                     default:
                         break;
                     }
-                } catch (BadLocationException e) {
                 } finally {
                     if (model instanceof AbstractDocument) {
                         ((AbstractDocument)model).readUnlock();

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -2697,10 +2697,7 @@ public class HTMLDocument extends DefaultStyledDocument {
                                                this, event));
                     }
                 }
-            }
-            catch (BadLocationException ble) {
-            }
-            finally {
+            } finally {
                 releaseLock();
             }
         }

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
@@ -360,7 +360,6 @@ public abstract class SunClipboard extends Clipboard
             try {
                 openClipboard(null);
                 currentFormats = getClipboardFormats();
-            } catch (final IllegalStateException ignored) {
             } finally {
                 closeClipboard();
             }

--- a/src/java.desktop/share/classes/sun/font/TrueTypeFont.java
+++ b/src/java.desktop/share/classes/sun/font/TrueTypeFont.java
@@ -138,7 +138,6 @@ public class TrueTypeFont extends FileFont {
                 if (channel != null) {
                     channel.close();
                 }
-            } catch (IOException e) {
             } finally {
                 channel = null;
             }

--- a/src/java.desktop/share/classes/sun/print/PSStreamPrintJob.java
+++ b/src/java.desktop/share/classes/sun/print/PSStreamPrintJob.java
@@ -156,7 +156,6 @@ public class PSStreamPrintJob implements CancelablePrintJob {
         if (instream != null) {
             try {
                 instream.close();
-            } catch (IOException e) {
             } finally {
                 instream = null;
             }
@@ -164,7 +163,6 @@ public class PSStreamPrintJob implements CancelablePrintJob {
         else if (reader != null) {
             try {
                 reader.close();
-            } catch (IOException e) {
             } finally {
                 reader = null;
             }

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
@@ -197,7 +197,6 @@ public class UnixPrintJob implements CancelablePrintJob {
         if (instream != null) {
             try {
                 instream.close();
-            } catch (IOException e) {
             } finally {
                 instream = null;
             }
@@ -205,7 +204,6 @@ public class UnixPrintJob implements CancelablePrintJob {
         else if (reader != null) {
             try {
                 reader.close();
-            } catch (IOException e) {
             } finally {
                 reader = null;
             }

--- a/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
+++ b/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
@@ -177,7 +177,6 @@ public class Win32PrintJob implements CancelablePrintJob {
         if (instream != null) {
             try {
                 instream.close();
-            } catch (IOException e) {
             } finally {
                 instream = null;
             }
@@ -185,7 +184,6 @@ public class Win32PrintJob implements CancelablePrintJob {
         else if (reader != null) {
             try {
                 reader.close();
-            } catch (IOException e) {
             } finally {
                 reader = null;
             }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -1235,7 +1235,6 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                 } finally {
                     lock.unlock();
                 }
-            } catch (IOException ignored) {
             } finally {
                 owner.stop();
             }

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPEndpoint.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPEndpoint.java
@@ -781,7 +781,6 @@ public class TCPEndpoint implements Endpoint {
 
             try {
                 name = InetAddress.getByName(hostAddress).getHostName();
-            } catch (java.net.UnknownHostException e) {
             } finally {
                 synchronized(this) {
                     reverseLookup = name;

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
@@ -719,11 +719,7 @@ public class DOMNormalizer implements XMLDocumentHandler {
             loader.setErrorHandler(fConfiguration.getErrorHandler());
             loader.loadGrammarWithContext((XMLDTDValidator) fValidationHandler, rootName,
                     publicId, systemId, baseSystemId, internalSubset);
-        }
-        // REVISIT: Should probably report this exception to the error handler.
-        catch (IOException e) {
-        }
-        finally {
+        } finally {
             if (loader != null) {
                 CoreDOMImplementationImpl.singleton.releaseDTDLoader(xmlVersion, loader);
             }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
@@ -147,8 +147,6 @@ class ChunkedOutputStream extends FilterOutputStream
                 is.close();
             }
         /* some clients close the connection before empty chunk is sent */
-        } catch (IOException e) {
-
         } finally {
             closed = true;
         }

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -742,7 +742,6 @@ public class TTY implements EventNotifier {
                     }
                 }
             }
-        } catch (IOException e) {
         } finally {
             if (inFile != null) {
                 try {

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestMembarDependencies.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestMembarDependencies.java
@@ -72,8 +72,6 @@ public class TestMembarDependencies {
             // Method call defines memory state that is then
             // used by subsequent instructions/blocks (see below).
             test_m1();
-        } catch (Exception e) {
-
         } finally {
             // Oop write to field emits a GC post-barrier with a MembarVolatile
             // which has a wide memory effect (kills all memory). This creates an

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
@@ -58,7 +58,6 @@ public class resexhausted002 {
             System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
             throw new SkippedException("Test did not get an OutOfMemory error");
 
-        } catch (OutOfMemoryError e) {
         } finally {
             stress.finish();
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/ThreadMXBean/MXBeanTestThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/ThreadMXBean/MXBeanTestThread.java
@@ -173,7 +173,6 @@ public class MXBeanTestThread extends Thread {
                     allocatedList = new ArrayList<Object>();
                 }
             }
-        } catch (OutOfMemoryError e) {
         } finally {
             stressAllocatedBytes += actuallyAllocated;
         }

--- a/test/jdk/java/awt/FullScreen/MultimonFullscreenTest/MultimonDeadlockTest.java
+++ b/test/jdk/java/awt/FullScreen/MultimonFullscreenTest/MultimonDeadlockTest.java
@@ -55,7 +55,6 @@ public class MultimonDeadlockTest {
                 }
             });
             Thread.sleep(5000);
-        } catch (InterruptedException | InvocationTargetException ex) {
         } finally {
             for (int i = 0; i < devices.length; i++) {
                 devices[i].setFullScreenWindow(null);

--- a/test/jdk/java/awt/print/PrinterJob/PrintAWTImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintAWTImage.java
@@ -67,7 +67,6 @@ public class PrintAWTImage extends Frame
        pj.setPrintable(this);
        try {
             pj.print();
-      } catch (PrinterException pe) {
       } finally {
          System.err.println("PRINT RETURNED");
       }

--- a/test/jdk/java/awt/print/PrinterJob/PrintBadImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintBadImage.java
@@ -43,7 +43,6 @@ public class PrintBadImage implements Printable {
           pj.setPrintable(pbi);
           try {
                pj.print();
-         } catch (PrinterException pe) {
          } finally {
             System.err.println("PRINT RETURNED");
          }

--- a/test/jdk/java/awt/print/PrinterJob/PrintCompoundString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintCompoundString.java
@@ -86,7 +86,6 @@ public class PrintCompoundString extends Frame implements ActionListener {
        pj.setPrintable(c);
        try {
             pj.print();
-      } catch (PrinterException pe) {
       } finally {
          System.err.println("PRINT RETURNED");
       }

--- a/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
@@ -88,7 +88,6 @@ public class PrintNullString extends Frame implements ActionListener {
        pj.setPrintable(c);
        try {
             pj.print();
-      } catch (PrinterException pe) {
       } finally {
          System.err.println("PRINT RETURNED");
       }

--- a/test/jdk/java/awt/print/PrinterJob/PrintParenString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintParenString.java
@@ -86,7 +86,6 @@ public class PrintParenString extends Frame implements ActionListener {
        pj.setPrintable(c);
        try {
             pj.print();
-      } catch (PrinterException pe) {
       } finally {
          System.err.println("PRINT RETURNED");
       }

--- a/test/jdk/java/awt/print/PrinterJob/PrintRotatedText.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintRotatedText.java
@@ -87,7 +87,6 @@ public class PrintRotatedText extends Frame implements ActionListener {
        pj.setPageable(c);
        try {
             pj.print();
-      } catch (PrinterException pe) {
       } finally {
          System.err.println("PRINT RETURNED");
       }

--- a/test/jdk/java/awt/print/PrinterJob/PrintTranslatedFont.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTranslatedFont.java
@@ -88,7 +88,6 @@ public class PrintTranslatedFont extends Frame implements ActionListener {
        pj.setPrintable(c);
        try {
             pj.print();
-      } catch (PrinterException pe) {
       } finally {
          System.err.println("PRINT RETURNED");
       }

--- a/test/jdk/java/awt/print/PrinterJob/PrintVolatileImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintVolatileImage.java
@@ -78,7 +78,6 @@ public class PrintVolatileImage extends Component
            pj.setPrintable(this);
            try {
                pj.print();
-           } catch (PrinterException pe) {
            } finally {
                System.err.println("PRINT RETURNED");
            }

--- a/test/jdk/java/awt/print/PrinterJob/raster/RasterTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/raster/RasterTest.java
@@ -89,7 +89,6 @@ public class RasterTest extends Frame implements ActionListener {
        pj.setPrintable(c);
        try {
             pj.print();
-      } catch (PrinterException pe) {
       } finally {
          System.err.println("PRINT RETURNED");
       }

--- a/test/jdk/java/io/File/createTempFile/TargetDirectory.java
+++ b/test/jdk/java/io/File/createTempFile/TargetDirectory.java
@@ -80,7 +80,6 @@ public class TargetDirectory {
         try {
             File.createTempFile("readonly", null, target);
             throw new RuntimeException("Exception not thrown for read-only target directory");
-        } catch (IOException expected) {
         } finally {
             target.delete();
         }
@@ -97,7 +96,6 @@ public class TargetDirectory {
         try {
             File.createTempFile("file", null, target);
             throw new RuntimeException("Exception not thrown for file target");
-        } catch (IOException expected) {
         } finally {
             target.delete();
         }

--- a/test/jdk/java/io/RandomAccessFile/Seek.java
+++ b/test/jdk/java/io/RandomAccessFile/Seek.java
@@ -43,7 +43,6 @@ public class Seek
             raf.seek(-10);
             throw new Exception
                 ("Should have thrown an IOException when seek offset is < 0");
-        } catch (IOException e) {
         } finally {
             raf.close();
         }

--- a/test/jdk/java/io/Serializable/duplicateSerialFields/Test.java
+++ b/test/jdk/java/io/Serializable/duplicateSerialFields/Test.java
@@ -88,7 +88,6 @@ public class Test {
             oin.readObject();
             throw new Error(
                 "read of A should fail with InvalidClassException");
-        } catch (InvalidClassException e) {
         } finally {
             in.close();
         }
@@ -99,7 +98,6 @@ public class Test {
             oin.readObject();
             throw new Error(
                 "read of B should fail with InvalidClassException");
-        } catch (InvalidClassException e) {
         } finally {
             in.close();
         }

--- a/test/jdk/java/io/Serializable/fieldTypeString/Read.java
+++ b/test/jdk/java/io/Serializable/fieldTypeString/Read.java
@@ -65,7 +65,6 @@ public class Read {
             ObjectInputStream oin = new ObjectInputStream(in);
             oin.readObject();
             throw new Error();
-        } catch (InvalidClassException ex) {
         } finally {
             in.close();
         }

--- a/test/jdk/java/net/URLConnection/ContentHandlers/ContentHandlersTest.java
+++ b/test/jdk/java/net/URLConnection/ContentHandlers/ContentHandlersTest.java
@@ -348,7 +348,6 @@ public class ContentHandlersTest {
         } finally {
             try {
                 src.close();
-            } catch (IOException ignored1) {
             } finally {
                 try {
                     dst.close();

--- a/test/jdk/java/net/URLConnection/DisconnectAfterEOF.java
+++ b/test/jdk/java/net/URLConnection/DisconnectAfterEOF.java
@@ -173,7 +173,6 @@ public class DisconnectAfterEOF {
                    }
                 }
 
-            } catch (IOException ioe) {
             } finally {
                 try {
                     s.close();

--- a/test/jdk/java/net/httpclient/DigestEchoServer.java
+++ b/test/jdk/java/net/httpclient/DigestEchoServer.java
@@ -1655,8 +1655,7 @@ public abstract class DigestEchoServer implements HttpServerAdapters {
                     end.whenComplete(
                             (r,t) -> {
                                 try { toClose.close(); } catch (IOException x) { }
-                                try { tc.close(); } catch (IOException x) { }
-                                finally {connectionCFs.remove(end);}
+                                try { tc.close(); } finally {connectionCFs.remove(end);}
                             });
                     connectionCFs.add(end);
                     targetConnection = clientConnection = null;

--- a/test/jdk/java/net/httpclient/HttpRedirectTest.java
+++ b/test/jdk/java/net/httpclient/HttpRedirectTest.java
@@ -323,13 +323,11 @@ public class HttpRedirectTest implements HttpServerAdapters {
         client = null;
         try {
             executor.awaitTermination(2000, TimeUnit.MILLISECONDS);
-        } catch (Throwable x) {
         } finally {
             executor.shutdownNow();
         }
         try {
             clientexec.awaitTermination(2000, TimeUnit.MILLISECONDS);
-        } catch (Throwable x) {
         } finally {
             clientexec.shutdownNow();
         }

--- a/test/jdk/java/net/httpclient/HttpSlowServerTest.java
+++ b/test/jdk/java/net/httpclient/HttpSlowServerTest.java
@@ -231,13 +231,11 @@ public class HttpSlowServerTest implements HttpServerAdapters {
         client = null;
         try {
             executor.awaitTermination(2000, TimeUnit.MILLISECONDS);
-        } catch (Throwable x) {
         } finally {
             executor.shutdownNow();
         }
         try {
             clientexec.awaitTermination(2000, TimeUnit.MILLISECONDS);
-        } catch (Throwable x) {
         } finally {
             clientexec.shutdownNow();
         }

--- a/test/jdk/java/net/httpclient/LargeResponseTest.java
+++ b/test/jdk/java/net/httpclient/LargeResponseTest.java
@@ -228,13 +228,11 @@ public class LargeResponseTest implements HttpServerAdapters {
         client = null;
         try {
             executor.awaitTermination(2000, TimeUnit.MILLISECONDS);
-        } catch (Throwable x) {
         } finally {
             executor.shutdownNow();
         }
         try {
             clientexec.awaitTermination(2000, TimeUnit.MILLISECONDS);
-        } catch (Throwable x) {
         } finally {
             clientexec.shutdownNow();
         }

--- a/test/jdk/java/net/httpclient/ProxyTest.java
+++ b/test/jdk/java/net/httpclient/ProxyTest.java
@@ -379,8 +379,7 @@ public class ProxyTest {
                     end = CompletableFuture.allOf(end1, end2);
                     end.whenComplete(
                             (r,t) -> {
-                                try { toClose.close(); } catch (IOException x) { }
-                                finally {connectionCFs.remove(end);}
+                                try { toClose.close(); } finally {connectionCFs.remove(end);}
                             });
                     connectionCFs.add(end);
                     t1.start();

--- a/test/jdk/java/net/httpclient/http2/ProxyTest2.java
+++ b/test/jdk/java/net/httpclient/http2/ProxyTest2.java
@@ -309,8 +309,7 @@ public class ProxyTest2 {
                     end = CompletableFuture.allOf(end1, end2);
                     end.whenComplete(
                             (r,t) -> {
-                                try { toClose.close(); } catch (IOException x) { }
-                                finally {connectionCFs.remove(end);}
+                                try { toClose.close(); } finally {connectionCFs.remove(end);}
                             });
                     connectionCFs.add(end);
                     t1.start();

--- a/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
+++ b/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
@@ -310,7 +310,6 @@ public class Basic {
         } finally {
             try {
                 src.close();
-            } catch (IOException ignored1) {
             } finally {
                 try {
                     dst.close();

--- a/test/jdk/java/nio/channels/FileChannel/Transfer.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer.java
@@ -336,7 +336,6 @@ public class Transfer {
         try {
             fc2.transferFrom(fc1, 0L, 0);
             throw new RuntimeException("NonReadableChannelException expected");
-        } catch (NonReadableChannelException expected) {
         } finally {
             fc1.close();
             fc2.close();

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/EchoService.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/EchoService.java
@@ -133,7 +133,6 @@ public class EchoService {
         public void run() {
             try {
                 doIt(sc, -1, -1);
-            } catch (IOException x) {
             } finally {
                 synchronized (lock) {
                     count--;

--- a/test/jdk/java/nio/file/Files/SBC.java
+++ b/test/jdk/java/nio/file/Files/SBC.java
@@ -236,7 +236,6 @@ public class SBC {
             try {
                 Files.newByteChannel(link, READ, LinkOption.NOFOLLOW_LINKS);
                 throw new RuntimeException();
-            } catch (IOException | UnsupportedOperationException x) {
             } finally {
                 TestUtil.deleteUnchecked(link);
             }

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -1451,7 +1451,6 @@ public class JSR166TestCase extends TestCase {
                 Policy.setPolicy(permissivePolicy());
                 System.setSecurityManager(new SecurityManager());
                 runWithSecurityManagerWithPermissions(r, permissions);
-            } catch (UnsupportedOperationException ok) {
             } finally {
                 try {
                     System.setSecurityManager(null);

--- a/test/jdk/javax/imageio/plugins/jpeg/JpegWriterLeakTest.java
+++ b/test/jdk/javax/imageio/plugins/jpeg/JpegWriterLeakTest.java
@@ -71,7 +71,6 @@ public class JpegWriterLeakTest {
 
 
                 // NB: dispose() or reset() workarounds the problem.
-            } catch (IOException e) {
             } finally {
                 writer = null;
             }

--- a/test/jdk/javax/naming/spi/providers/InitialContextTest.java
+++ b/test/jdk/javax/naming/spi/providers/InitialContextTest.java
@@ -347,7 +347,6 @@ public class InitialContextTest {
         } finally {
             try {
                 src.close();
-            } catch (IOException ignored1) {
             } finally {
                 try {
                     dst.close();

--- a/test/jdk/javax/sound/sampled/AudioInputStream/FrameLengthAfterConversion.java
+++ b/test/jdk/javax/sound/sampled/AudioInputStream/FrameLengthAfterConversion.java
@@ -166,8 +166,6 @@ public final class FrameLengthAfterConversion {
             final long frameLength = ais.getFrameLength();
             ais.close();
             validate(frameLength);
-        } catch (IllegalArgumentException | UnsupportedAudioFileException
-                ignored) {
         } finally {
             Files.delete(Paths.get(temp.getAbsolutePath()));
         }

--- a/test/jdk/sun/net/www/http/HttpClient/ProxyTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/ProxyTest.java
@@ -156,7 +156,6 @@ public class ProxyTest {
                     client = server.accept();
                     (new HttpProxyHandler(client)).start();
                 }
-            } catch (Exception e) {
             } finally {
                 try { server.close(); } catch (IOException unused) {}
             }

--- a/test/jdk/sun/net/www/protocol/http/ProtocolRedirect.java
+++ b/test/jdk/sun/net/www/protocol/http/ProtocolRedirect.java
@@ -89,7 +89,6 @@ class Redirect implements Runnable, Closeable {
         stopped = true;
         try {
             if (s != null) s.close();
-        } catch (Throwable x) {
         } finally {
             try { ssock.close(); } catch (Throwable x) {}
         }

--- a/test/jdk/sun/nio/cs/MalformedSurrogates.java
+++ b/test/jdk/sun/nio/cs/MalformedSurrogates.java
@@ -75,7 +75,6 @@ public class MalformedSurrogates {
         try {
             en.encode(CharBuffer.wrap(surrogate));
             throw new RuntimeException("Should throw MalformedInputException or UnmappableCharacterException");
-        } catch (MalformedInputException | UnmappableCharacterException ex) {
         } finally {
             en.reset();
         }
@@ -91,7 +90,6 @@ public class MalformedSurrogates {
         CharsetEncoder en = cs.newEncoder();
         try {
             en.encode(CharBuffer.wrap(surrogate));
-        } catch (UnmappableCharacterException ex) {
         } finally {
             en.reset();
         }

--- a/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
+++ b/test/langtools/jdk/javadoc/tool/CheckResourceKeys.java
@@ -274,7 +274,6 @@ public class CheckResourceKeys {
                         results.add(v);
                 }
             }
-        } catch (ConstantPoolException ignore) {
         } finally {
             in.close();
         }

--- a/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
+++ b/test/langtools/tools/javac/T8022186/DeadCodeGeneratedForEmptyTryTest.java
@@ -217,7 +217,7 @@ public class DeadCodeGeneratedForEmptyTryTest {
         void methodToLookFor() {
             try {
                 // empty try statement
-                try { } catch (Exception e) { } finally { }
+                try { } finally { }
             } catch (Exception e) {
                 System.out.println("EXCEPTION");
             } finally {
@@ -241,7 +241,7 @@ public class DeadCodeGeneratedForEmptyTryTest {
         void methodToLookFor() {
             try {
                 // empty try statement with skip statement
-                try { ; } catch (Exception e) { } finally { }
+                try { ; } finally { }
             } catch (Exception e) {
                 System.out.println("EXCEPTION");
             } finally {

--- a/test/langtools/tools/javac/flow/tests/TestCaseTry.java
+++ b/test/langtools/tools/javac/flow/tests/TestCaseTry.java
@@ -24,9 +24,7 @@ public class TestCaseTry {
         try {
             o = "";
             o.hashCode();
-        } catch (RuntimeException e) {
-        }
-        finally {
+        } finally {
             o = "finally";
             o.hashCode();
         }


### PR DESCRIPTION
Find try-catch-finally statements where the catch statement has no body (the catch clause could be omitted)

[_Created by Sourcegraph batch change `kevin.matthews/java-remove-catch`._](https://demo.sourcegraph.com/users/kevin.matthews/batch-changes/java-remove-catch)